### PR TITLE
Ndg8f/manu 6103/term with space fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # System Files
 .DS_Store
 Thumbs.db
+.idea

--- a/js/kmaps-simple-typeahead.js
+++ b/js/kmaps-simple-typeahead.js
@@ -120,7 +120,7 @@
                 solr_query = settings.autocomplete_field + ':' + val;
                 if (settings.search_fields) {
                   solr_query = settings.search_fields.reduce(function (full_query, search_field) {
-                    return full_query + " OR " + search_field + ":" + val.replace(/[\s]+/g, '\\ ');
+                    return full_query + " OR " + search_field + ":" + val.replace(/[\s]+/g, '\\%20');
                   }, solr_query);
                 }
               }


### PR DESCRIPTION
**Jira Issue:** MANU-6103

**Changes proposed in this pull request:**

 + Simply replaced the space with %20 in the term value replace call on line 123
 + Added .idea (PHPStorm folder) to .gitignore

**Details of the implementation:**

In the Drupal sites, searches for terms with spaces such as "chos dbying" were not working because the space was getting turned into a "+" and this broke the SOLR query. Replacing the 
space with %20 fixes this.
